### PR TITLE
On hold: Build hdf5 1.12.1 coherently for all architectures

### DIFF
--- a/recipe/0001-ppc64le-uses-special-algorithm-for-long-double.patch
+++ b/recipe/0001-ppc64le-uses-special-algorithm-for-long-double.patch
@@ -8,10 +8,10 @@ Subject: [PATCH 1/2] ppc64le uses special algorithm for long double
  1 file changed, 14 insertions(+)
 
 diff --git a/config/cmake/ConversionTests.c b/config/cmake/ConversionTests.c
-index 082dbd4..c86caf7 100644
+index f80959fdc7..b25b3246f9 100644
 --- a/config/cmake/ConversionTests.c
 +++ b/config/cmake/ConversionTests.c
-@@ -23,6 +23,13 @@ int main(void)
+@@ -34,6 +34,13 @@ int HDF_NO_UBSAN main(void)
      unsigned char       s2[8];
      int                 ret = 1;
  
@@ -23,9 +23,9 @@ index 082dbd4..c86caf7 100644
 +         ret = 0;
 +    #endif
      if(sizeof(long double) == 16 && sizeof(long) == 8) {
- 	/*make sure the long double type has 16 bytes in size and
- 	 * 11 bits of exponent.  If it is,
-@@ -83,6 +90,13 @@ int main(void)
+     /*make sure the long double type has 16 bytes in size and
+     * 11 bits of exponent.  If it is,
+@@ -94,6 +101,13 @@ int HDF_NO_UBSAN main(void)
      unsigned char       s[16];
      int                 flag=0, ret=1;
  
@@ -39,6 +39,3 @@ index 082dbd4..c86caf7 100644
      /*Determine if long double has 16 byte in size, 11 bit exponent, and
       *the bias is 0x3ff */
      if(sizeof(long double) == 16) {
--- 
-1.8.3.1
-

--- a/recipe/0002-long-double-conversion-tests-on-ppc64le.patch
+++ b/recipe/0002-long-double-conversion-tests-on-ppc64le.patch
@@ -8,14 +8,14 @@ Subject: [PATCH 2/2] long double conversion tests on ppc64le
  1 file changed, 24 insertions(+), 2 deletions(-)
 
 diff --git a/test/dt_arith.c b/test/dt_arith.c
-index c7f2986..528d34f 100644
+index 0ce147541a..76f2f4c743 100644
 --- a/test/dt_arith.c
 +++ b/test/dt_arith.c
-@@ -3051,7 +3051,18 @@ test_conv_flt_1 (const char *name, int run_test, hid_t src, hid_t dst)
-                         buf, saved, nelmts);
- #if H5_SIZEOF_LONG_DOUBLE!=H5_SIZEOF_DOUBLE && H5_SIZEOF_LONG_DOUBLE!=0
-             } else if(src_type == FLT_LDOUBLE) {
--                 INIT_FP_SPECIAL(src_size, src_nbits, sendian, LDBL_MANT_DIG, dst_size,
+@@ -3130,7 +3130,18 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
+ #if H5_SIZEOF_LONG_DOUBLE != H5_SIZEOF_DOUBLE && H5_SIZEOF_LONG_DOUBLE != 0
+             }
+             else if (src_type == FLT_LDOUBLE) {
+-                INIT_FP_SPECIAL(src_size, src_nbits, sendian, LDBL_MANT_DIG, dst_size, buf, saved, nelmts);
 +                size_t mant_dig = LDBL_MANT_DIG;
 +                if (mant_dig >= src_nbits) {
 +                    /* This happens for IBM long double in little endian.
@@ -27,30 +27,27 @@ index c7f2986..528d34f 100644
 +                       override the mantissa size.  */
 +                    mant_dig = 52;
 +                }
-+                 INIT_FP_SPECIAL(src_size, src_nbits, sendian, mant_dig, dst_size,
-                         buf, saved, nelmts);
++                INIT_FP_SPECIAL(src_size, src_nbits, sendian, mant_dig, dst_size, buf, saved, nelmts);
  #endif
-             } else
-@@ -3711,7 +3722,18 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
-             INIT_FP_DENORM(long double, LDBL_MANT_DIG, src_size, src_nbits, sendian, dst_size,
-                     buf, saved, nelmts);
-         } else {
+             }
+             else
+@@ -3840,7 +3851,18 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
+                            nelmts);
+         }
+         else {
 -            INIT_FP_SPECIAL(src_size, src_nbits, sendian, LDBL_MANT_DIG, dst_size, buf, saved, nelmts);
-+           size_t mant_dig = LDBL_MANT_DIG;
-+           if (mant_dig >= src_nbits) {
-+               /* This happens for IBM long double in little endian.
-+                  The macro LDBL_MANT_DIG says 106 mantissa bits, but the
-+                  HDF5 detection code actually represents it as a normal 64bit
-+                  double (52 bit mantissa) with the upper double being
-+                  unspec bits (which is sort of okay as the testsuite
-+                  wouldn't deal with that format correctly anyway).  So
-+                  override the mantissa size.  */
-+               mant_dig = 52;
-+           }
++            size_t mant_dig = LDBL_MANT_DIG;
++            if (mant_dig >= src_nbits) {
++                /* This happens for IBM long double in little endian.
++                   The macro LDBL_MANT_DIG says 106 mantissa bits, but the
++                   HDF5 detection code actually represents it as a normal 64bit
++                   double (52 bit mantissa) with the upper double being
++                   unspec bits (which is sort of okay as the testsuite
++                   wouldn't deal with that format correctly anyway).  So
++                   override the mantissa size.  */
++                mant_dig = 52;
++            }
 +            INIT_FP_SPECIAL(src_size, src_nbits, sendian, mant_dig, dst_size, buf, saved, nelmts);
          }
  #endif
-     } else
--- 
-1.8.3.1
-
+     }

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,19 +4,15 @@
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./config
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./bin
 
-export LIBRARY_PATH="${PREFIX}/lib"
-
 export CC=$(basename ${CC})
 export CXX=$(basename ${CXX})
 export F95=$(basename ${F95})
 export FC=$(basename ${FC})
 export GFORTRAN=$(basename ${GFORTRAN})
 
-if [ "${target_platform}" = "osx-64" ]; then
-    # Work around a problem on osx-64 where apparently the SDK libdirs are
-    # not in the library search path.
-    export LDFLAGS="${LDFLAGS} -L${SDKROOT}/usr/lib -L${SDKROOT}/usr/lib/system"
-fi
+echo "--tkoch--"
+ls -l /opt
+echo "--tkoch--"
 
 ./configure --prefix="${PREFIX}" \
             --host="${HOST}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Get an updated config.sub and config.guess
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./config
@@ -11,6 +11,12 @@ export CXX=$(basename ${CXX})
 export F95=$(basename ${F95})
 export FC=$(basename ${FC})
 export GFORTRAN=$(basename ${GFORTRAN})
+
+if [ "${target_platform}" = "osx-64" ]; then
+    # Work around a problem on osx-64 where apparently the SDK libdirs are
+    # not in the library search path.
+    export LDFLAGS="${LDFLAGS} -L${SDKROOT}/usr/lib -L${SDKROOT}/usr/lib/system"
+fi
 
 ./configure --prefix="${PREFIX}" \
             --host="${HOST}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,11 +32,11 @@ export GFORTRAN=$(basename ${GFORTRAN})
             --with-ssl
 
 make -j "${CPU_COUNT}" ${VERBOSE_AT}
-if [[ ! ${HOST} =~ .*powerpc64le.* ]]; then
-  # https://github.com/h5py/h5py/issues/817
-  # https://forum.hdfgroup.org/t/hdf5-1-10-long-double-conversions-tests-failed-in-ppc64le/4077
-  make check
-fi
+#if [[ ! ${HOST} =~ .*powerpc64le.* ]]; then
+#  # https://github.com/h5py/h5py/issues/817
+#  # https://forum.hdfgroup.org/t/hdf5-1-10-long-double-conversions-tests-failed-in-ppc64le/4077
+#  make check
+#fi
 make install
 
 rm -rf $PREFIX/share/hdf5_examples

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,11 +38,11 @@ fi
             --with-ssl
 
 make -j "${CPU_COUNT}" ${VERBOSE_AT}
-#if [[ ! ${HOST} =~ .*powerpc64le.* ]]; then
-#  # https://github.com/h5py/h5py/issues/817
-#  # https://forum.hdfgroup.org/t/hdf5-1-10-long-double-conversions-tests-failed-in-ppc64le/4077
-#  make check
-#fi
+if [[ ! ${HOST} =~ .*powerpc64le.* ]]; then
+  # https://github.com/h5py/h5py/issues/817
+  # https://forum.hdfgroup.org/t/hdf5-1-10-long-double-conversions-tests-failed-in-ppc64le/4077
+  make check
+fi
 make install
 
 rm -rf $PREFIX/share/hdf5_examples

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,5 @@
 # this is a hack for libtool, which doesn't know about SDK 11.x, so we use here 10.15 instead
-MACOSX_DEPLOYMENT_TARGET:  # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx]
+  - 10.11                  # [osx and x86_64]
   - 10.15                  # [osx and arm64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ build:
     #    This pinning is using the implicitly defined output for the top-level recipe.
     #    We use pin_subpackage here so that we have more control over the pinning.
     - {{ pin_subpackage('hdf5', min_pin='x.x.x', max_pin='x.x.x') }}
+  ignore_run_exports:
+    - {{ compiler('fortran') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,10 @@ source:
   url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ maj_min_ver }}/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
   sha256: 79c66ff67e666665369396e9c90b32e238e501f345afd2234186bfb8331081ca
   patches:
-    # Patches the test suite to skip the cache, cache_image, and fheap tests
-    # This test has been found to rather resource intensive.
-    # In particular, it caused Travis CI's Mac builds to hang.
-    # Given that we simply skip the test on all platforms.
-    #- test_Makefile.in.patch
+    # Patches the test suite to skip the cache, cache_image, and fheap tests,
+    # which haves been found to be rather resource intensive. In particular,
+    # they cause Mac builds to hang on osx-arm64.
+    - test_Makefile.in.patch  # [osx and arm64]
     # Disable shared Fortran API building on OSX
     - osx_configure.patch  # [osx]
     # https://bugzilla.redhat.com/show_bug.cgi?id=1078173

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -134,8 +134,8 @@ about:
   description: |
     HDF5 supports an unlimited variety of datatypes, and is designed for
     flexible and efficient I/O and for high volume and complex data.
-  doc_url: https://www.hdfgroup.org/HDF5/doc/
-  dev_url: https://www.hdfgroup.org/HDF5/release/obtain5.html
+  doc_url: https://docs.hdfgroup.org/hdf5/develop/
+  dev_url: https://www.hdfgroup.org/downloads/hdf5/source-code/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ build:
   ignore_run_exports:
     - {{ compiler('fortran') }}
     - libgfortran5  # [osx and arm64]
+    - libcurl  # [win]
+    - openssl  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ build:
     - {{ pin_subpackage('hdf5', min_pin='x.x.x', max_pin='x.x.x') }}
   ignore_run_exports:
     - {{ compiler('fortran') }}
+    - libgfortran5  # [osx and arm64]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - make           # [not win]
     - cmake >=3.1    # [win]
     - jom            # [win]
+    - patch          # [ppc64le]
   host:
     - zlib
     - libcurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ maj_min_ver }}/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
   sha256: 79c66ff67e666665369396e9c90b32e238e501f345afd2234186bfb8331081ca
   patches:
-    # Patches the test suite to skip the cache, cache_image, and fheap tests,
-    # which haves been found to be rather resource intensive. In particular,
-    # they cause Mac builds to hang on osx-arm64.
+    # Patches the test suite to skip the cache, cache_image, fheap and swmr
+    # tests, which haves been found to be rather resource intensive.
+    # In particular, they cause Mac builds to hang on osx-arm64.
     - test_Makefile.in.patch  # [osx and arm64]
     # Disable shared Fortran API building on OSX
     - osx_configure.patch  # [osx]
@@ -22,7 +22,7 @@ source:
     - 0002-long-double-conversion-tests-on-ppc64le.patch         # [ppc64le]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,9 @@ requirements:
     - cmake >=3.1    # [win]
     - jom            # [win]
     - patch          # [ppc64le]
+    # For some reason the `strings` command is not available on aarch64 without
+    # this explicit dependency.
+    - binutils       # [aarch64]
   host:
     - zlib
     - libcurl

--- a/recipe/test_Makefile.in.patch
+++ b/recipe/test_Makefile.in.patch
@@ -1,5 +1,5 @@
 diff --git a/test/Makefile.in b/test/Makefile.in
-index c2a5ee1f42..1f754eb948 100644
+index c2a5ee1f42..734da89e0a 100644
 --- a/test/Makefile.in
 +++ b/test/Makefile.in
 @@ -1590,8 +1590,8 @@ check_SCRIPTS = $(TEST_SCRIPT)
@@ -13,3 +13,12 @@ index c2a5ee1f42..1f754eb948 100644
             pool accum hyperslab istore bittests dt_arith page_buffer \
             dtypes dsets chunk_info cmpd_dset cmpd_dtransform filter_fail extend direct_chunk \
             external efc objcopy objcopy_ref links unlink twriteorder big mtime \
+@@ -1599,7 +1599,7 @@ TEST_PROG = testhdf5 \
+            flush1 flush2 app_ref enum set_extent ttsafe enc_dec_plist \
+            enc_dec_plist_cross_platform getname vfd ros3 s3comms hdfs ntypes \
+            dangle dtransform reserved cross_read freespace mf vds file_image \
+-           unregister cache_logging cork swmr thread_id vol timer
++           unregister cache_logging cork thread_id vol timer
+ 
+ 
+ # These programs generate test files for the tests.  They don't need to be

--- a/recipe/test_Makefile.in.patch
+++ b/recipe/test_Makefile.in.patch
@@ -1,13 +1,15 @@
---- hdf5-1.10.1.orig/test/Makefile.in	2017-04-27 15:56:04.000000000 -0300
-+++ hdf5-1.10.1/test/Makefile.in	2017-06-14 15:33:31.096078745 -0300
-@@ -1381,8 +1381,8 @@
+diff --git a/test/Makefile.in b/test/Makefile.in
+index c2a5ee1f42..1f754eb948 100644
+--- a/test/Makefile.in
++++ b/test/Makefile.in
+@@ -1590,8 +1590,8 @@ check_SCRIPTS = $(TEST_SCRIPT)
  # As an exception, long-running tests should occur earlier in the list.
  # This gives them more time to run when tests are executing in parallel.
  TEST_PROG = testhdf5 \
--           cache cache_api cache_image cache_tagging lheap ohdr stab gheap \
--           evict_on_close farray earray btree2 fheap \
-+           cache_api cache_tagging lheap ohdr stab gheap \
-+           evict_on_close farray earray btree2 \
+-           cache cache_api cache_image cache_tagging lheap ohdr \
+-           stab gheap evict_on_close farray earray btree2 fheap \
++           cache_api cache_tagging lheap ohdr \
++           stab gheap evict_on_close farray earray btree2 \
             pool accum hyperslab istore bittests dt_arith page_buffer \
-            dtypes dsets cmpd_dset filter_fail extend external efc objcopy links unlink \
-            twriteorder big mtime fillval mount flush1 flush2 app_ref enum \
+            dtypes dsets chunk_info cmpd_dset cmpd_dtransform filter_fail extend direct_chunk \
+            external efc objcopy objcopy_ref links unlink twriteorder big mtime \


### PR DESCRIPTION
The diff between 1.12.0 and 1.12.1 is huge (57MB uncompressed text). It looks like it is mostly build system updates and fixes, but impossible to review the whole thing.

Packages depending on hdf5:

* caffe
* caffe-gpu
* h5py
* kealib
* libgdal
* libnetcdf
* libopencv
* netcdf4
* opencv
* pynio
* pytables
* vtk
* yt

All of them depend on specific versions of hdf5, none of them depends on version 1.12.

Summary:

* Rebase ppc64le patches.
* Skip some tests on osx-arm64 as they cause the builder to malfunction (not always but most of the time).
* Work around linking problem on osx-64.
* Depend on binutils on linux-aarch64, because the host does not have the `strings` command installed.
* Fix ignore_run_exports on Windows.

Current situation:

```
--------------------------------------------------------------------
# linux-64
--------------------------------------------------------------------
* hdf5                          1.12.0      hc3cf35f_0  pkgs/main
* hdf5                          1.12.1      h69dfa17_1  pkgs/main

--------------------------------------------------------------------
# linux-ppc64le
--------------------------------------------------------------------
* hdf5                          1.12.0      h1b00688_0  pkgs/main

--------------------------------------------------------------------
# linux-aarch64
--------------------------------------------------------------------
* hdf5                          1.12.0      h702ddfa_1  pkgs/main
* hdf5                          1.12.0      hcdd0750_0  pkgs/main

--------------------------------------------------------------------
# linux-s390x
--------------------------------------------------------------------
* hdf5                          1.12.0      h5c1ab14_0  pkgs/main

--------------------------------------------------------------------
# osx-64
--------------------------------------------------------------------
* hdf5                          1.12.0      h964e04d_0  pkgs/main

--------------------------------------------------------------------
# osx-arm64
--------------------------------------------------------------------
* hdf5                          1.12.0      h9deaf1a_0  pkgs/main
* hdf5                          1.12.1      h5aa262f_0  pkgs/main
* hdf5                          1.12.1      h5aa262f_1  pkgs/main

--------------------------------------------------------------------
# win-32
--------------------------------------------------------------------
* hdf5                          1.12.0      h519f517_0  pkgs/main

--------------------------------------------------------------------
# win-64
--------------------------------------------------------------------
* hdf5                          1.12.0      h1756f20_0  pkgs/main

```