### PR TITLE
Rebuild hdf5 against libgfortran5

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -20,9 +20,9 @@ cmake -G "NMake Makefiles" ^
 if errorlevel 1 exit 1
 
 :: Build C libraries and tools.
-jom
+cmake --build .
 if errorlevel 1 exit 1
 
 :: Install step.
-jom install
+cmake --install .
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,10 @@ export F95=$(basename ${F95})
 export FC=$(basename ${FC})
 export GFORTRAN=$(basename ${GFORTRAN})
 
+if [ $(uname -s) = "Linux" ] && [ ! -f "${BUILD_PREFIX}/bin/strings" ]; then
+    ln -s "${BUILD}-strings" "${BUILD_PREFIX}/bin/strings"
+fi
+
 ./configure --prefix="${PREFIX}" \
             --host="${HOST}" \
             --build="${BUILD}" \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ source:
 
 build:
   number: 1
+  # This version does not support osx-arm64.
+  skip: True  # [osx and arm64]
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.
@@ -39,6 +41,7 @@ requirements:
     - make           # [not win]
     - cmake >=3.1    # [win]
     - jom            # [win]
+    - patch          # [osx or ppc64le]
   host:
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,6 @@ test:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    # For the `strings` command
-    - binutils  # [linux]
 
   files:
     - h5_cmprss.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ build:
   number: 1
   # This version does not support osx-arm64.
   skip: True  # [osx and arm64]
+  ignore_run_exports:
+    - libgfortran5  # [osx]
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ test:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
     # For the `strings` command
-    - binutils
+    - binutils  # [linux]
 
   files:
     - h5_cmprss.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ build:
   skip: True  # [osx and arm64]
   ignore_run_exports:
     - libgfortran5  # [osx]
+    - zlib          # [win]
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - libtool        # [not win]
     - make           # [not win]
     - cmake >=3.1    # [win]
-    - m2-perl        # [win]
     - patch          # [osx or ppc64le]
   host:
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - make           # [not win]
     - cmake >=3.1    # [win]
     - jom            # [win]
+    - m2-perl        # [win]
     - patch          # [osx or ppc64le]
   host:
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - 0002-long-double-conversion-tests-on-ppc64le.patch         # [ppc64le]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,8 @@ test:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
+    # For the `strings` command
+    - binutils
 
   files:
     - h5_cmprss.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - libtool        # [not win]
     - make           # [not win]
     - cmake >=3.1    # [win]
-    - jom            # [win]
     - m2-perl        # [win]
     - patch          # [osx or ppc64le]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,7 +121,7 @@ test:
     {% endfor %}
 
 about:
-  home: http://www.hdfgroup.org/HDF5/
+  home: https://www.hdfgroup.org/HDF5/
   license: HDF5
   license_family: BSD
   license_file: COPYING


### PR DESCRIPTION
Required for OpenCV.