### PR TITLE
Use cmake

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,22 +15,30 @@ fi
 mkdir build
 cd build
 
-cmake -G "Unix Makefiles" \
-      -D CMAKE_BUILD_TYPE=RELEASE \
-      -D CMAKE_PREFIX_PATH="$PREFIX" \
-      -D CMAKE_INSTALL_PREFIX="$PREFIX" \
-      -D HDF5_BUILD_CPP_LIB=ON \
-      -D HDF5_BUILD_FORTRAN=ON \
-      -D BUILD_SHARED_LIBS=ON \
-      -D BUILD_STATIC_LIBS=OFF \
-      -D HDF5_BUILD_HL_LIB=ON \
-      -D HDF5_BUILD_TOOLS=ON \
-      -D HDF5_ENABLE_Z_LIB_SUPPORT=ON \
-      -D HDF5_ENABLE_SZIP_SUPPORT=OFF \
-      -D HDF5_ENABLE_THREADSAFE=ON \
-      -D ALLOW_UNSUPPORTED=ON \
-      -D ZLIB_DIR="$PREFIX" \
-      "$SRC_DIR"
+cmake_flags=(
+    -D CMAKE_BUILD_TYPE=RELEASE
+    -D CMAKE_PREFIX_PATH="$PREFIX"
+    -D CMAKE_INSTALL_PREFIX="$PREFIX"
+    -D HDF5_BUILD_CPP_LIB=ON
+    -D HDF5_BUILD_FORTRAN=ON
+    -D BUILD_SHARED_LIBS=ON
+    -D BUILD_STATIC_LIBS=ON
+    -D HDF5_BUILD_HL_LIB=ON
+    -D HDF5_BUILD_TOOLS=ON
+    -D HDF5_ENABLE_Z_LIB_SUPPORT=ON
+    -D HDF5_ENABLE_SZIP_SUPPORT=OFF
+    -D HDF5_ENABLE_THREADSAFE=ON
+    -D ALLOW_UNSUPPORTED=ON
+    -D ZLIB_DIR="$PREFIX"
+)
+
+# Apply extra flags for Linux only
+if [[ $(uname) == "Linux" ]]; then
+    cmake_flags+=(-D CMAKE_C_FLAGS="-pthread -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib -lz")
+fi
+
+
+cmake -G "Unix Makefiles" "${cmake_flags[@]}" "$SRC_DIR"
 
 # Build C libraries and tools.
 cmake --build .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,3 +45,18 @@ cmake --build .
 cmake --install .
 
 rm -rf $PREFIX/share/hdf5_examples
+
+# Restore compatibility with hdf5 built with autotools
+# Create symlinks for libhdf5hl* from existing libhdf5_hl*
+for file in $PREFIX/lib/libhdf5_hl*; do
+    # Extract base filename
+    base_name=$(basename "$file")
+
+    # Replace "libhdf5_hl" with "libhdf5hl" in the filename
+    new_name="${base_name/libhdf5_hl/libhdf5hl}"
+
+    # Create symlink only if the destination does not exist
+    if [[ ! -e "$PREFIX/lib/$new_name" ]]; then
+        ln -s "$file" "$PREFIX/lib/$new_name"
+    fi
+done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ec2e13c52e60f9a01491bb3158cb3778c985697131fc6a342262d32a26e58e44
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # hdf5 has historically broken API between bugfix revisions.  Pin it to be safe.
     #    This pinning is using the implicitly defined output for the top-level recipe.
@@ -22,9 +22,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - libtool        # [not win]
-    - make           # [not win]
-    - cmake >=3.1    # [win]
+    - make  # [linux]
+    - cmake >=3.1 
   host:
     - zlib {{ zlib }}
     - libcurl 7.88.1  # [not win]
@@ -55,7 +54,6 @@ test:
         "h5c++",
         "h5cc",
         "h5perf_serial",
-        "h5redeploy",
         "h5fc"
     ] %}
     {% for each_hdf5_unix_cmd in hdf5_unix_cmds %}
@@ -90,7 +88,6 @@ test:
         "hdf5_hl_cpp"
     ] %}
     {% for each_hdf5_lib in hdf5_libs %}
-    - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.a                           # [unix]
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.dylib                       # [osx]
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.so                          # [linux]
     - if not exist %PREFIX%\\Library\\lib\\{{ each_hdf5_lib }}.lib exit 1    # [win]
@@ -106,6 +103,7 @@ test:
     - echo "Testing h5cc"            # [unix]
     - h5cc -show                     # [unix]
     - h5cc h5_cmprss.c -o h5_cmprss  # [unix]
+    - export DYLD_LIBRARY_PATH=$PREFIX/lib:$DYLD_LIBRARY_PATH  # [osx]
     - ./h5_cmprss                    # [unix]
 
     # Test C++ compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ test:
         "hdf5_hl_cpp"
     ] %}
     {% for each_hdf5_lib in hdf5_libs %}
+    - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.a                           # [unix]
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.dylib                       # [osx]
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.so                          # [linux]
     - if not exist %PREFIX%\\Library\\lib\\{{ each_hdf5_lib }}.lib exit 1    # [win]
@@ -104,6 +105,7 @@ test:
     - h5cc -show                     # [unix]
     - h5cc h5_cmprss.c -o h5_cmprss  # [unix]
     - export DYLD_LIBRARY_PATH=$PREFIX/lib:$DYLD_LIBRARY_PATH  # [osx]
+    - export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH      # [linux]
     - ./h5_cmprss                    # [unix]
 
     # Test C++ compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,7 +85,7 @@ test:
         "hdf5",
         "hdf5_cpp",
         "hdf5_hl",
-        "hdf5_hl_cpp"
+        "hdf5_hl_cpp",
     ] %}
     {% for each_hdf5_lib in hdf5_libs %}
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.a                           # [unix]


### PR DESCRIPTION
hdf5 rebuild

## Changes
- Switch from autotools to cmake
- `h5redeploy` is no longer built as it's not needed when building with cmake. 
	- HDF5 now handles shared library relocation correctly via RPATH adjustments at build time.
	- h5redeploy was only needed for certain relocatable builds where paths to shared libraries had to be rewritten.
- Ensure the dylibs/sos are backwards compatible with build 0. 
    - Auto tools produces some libs like: `lib/libhdf5hl_fortran.so` where cmake produces `lib/libhdf5_hl_fortran.so`
    - Add a symlink for each of those cases


## Notes
- This unblocks https://github.com/AnacondaRecipes/kealib-feedstock/pull/6
